### PR TITLE
Allow updating only part of the buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Discussion about this driver: http://forum.micropython.org/viewtopic.php?f=5&t=3
 Changelog
 ---------
 
+* 1.3 - Allow updating only part of the buffer; re-add send_buf
 * 1.2 - Disable IRQ feature removed. (It's not neccesary in newer versions of
   MicroPython.)
 * 1.1 - Speed optimisations.


### PR DESCRIPTION
Thank you for this great driver! _Máš u mě pivo_ :)

Here is a change that allows updating only part of the buffer at a time. I used this to make a simple game: https://www.youtube.com/watch?v=fwyFTVJoppA&index=20&list=PLFt-PM7J_H3GK-Ry_7X2pKdVfdlUPzZM2

The game was created with version 1.1 of micropython-ws2812, which was too slow to do a full update in each frame. From the speed point of view, it might not be necessary anymore. But it's still good for memory: I can "paint" objects onto the buffer, rather than preparing everything in an extra list and then `show()`ing that.
