### PR TITLE
Compatibility with standard micropython neopixel

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Discussion about this driver: http://forum.micropython.org/viewtopic.php?f=5&t=3
 Changelog
 ---------
 
+* 1.4 - Updates for builtin neopixel compatibility
 * 1.3 - Allow updating only part of the buffer; re-add send_buf
 * 1.2 - Disable IRQ feature removed. (It's not neccesary in newer versions of
   MicroPython.)

--- a/ws2812.py
+++ b/ws2812.py
@@ -24,7 +24,7 @@ class WS2812:
         ]
         chain.show(data)
 
-    Version: 1.1
+    Version: 1.4
     """
     buf_bytes = (0x88, 0x8e, 0xe8, 0xee)
 


### PR DESCRIPTION
These changes should make the library a swap in replacement for code that uses the standard MicroPython builtin neopixel library.

That is by replacing:

    import neopixel
    npixels = neopixel.NeoPixel(NeoPin,led_count)

with:

    try:
        import ws2812
        npixels = ws2812.WS2812(SPI_BUS,led_count)
    except:
        import neopixel
        npixels = neopixel.NeoPixel(NeoPin,led_count)

existing code that uses neopixels should work on boards with the builtin library or boards that don't have the neopixel library but have ws2812 neopixels connected to the MOSI pin of the SPI bus.